### PR TITLE
fix: http executor should forward body

### DIFF
--- a/executors/http/executor.go
+++ b/executors/http/executor.go
@@ -1,9 +1,9 @@
 package http
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -63,7 +63,8 @@ func (Executor) Run(l *log.Entry, aliases venom.Aliases, step venom.TestStep) (v
 	}
 
 	r := Result{Executor: t}
-	var body io.Reader
+
+	body := bytes.NewBuffer([]byte(t.Body))
 
 	path := t.URL + t.Path
 	method := t.Method


### PR DESCRIPTION
Hi,

the executor is not forwarding JSON body, now it will.

Signed-off-by: Geoffrey Bauduin <bauduin.geo@gmail.com>