### PR TITLE
feature: HTTP executor can POST multipart

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,22 @@ testcases:
     - result.statuscode ShouldEqual 200
     - result.bodyjson.apis.apis0.path ShouldEqual /allDom
 
+- name: POST http with multipart
+  steps:
+  - type: http
+    method: POST
+    url: https://eu.api.ovh.com/1.0/
+    multipart_form:
+        file: '@/tmp/myfile.tmp'
+    assertions:
+    - result.statuscode ShouldNotEqual 200
 ```
+*NB: to post a file, prefix the path to the file with '@'*
+
+
+### SMTP
+
+See https://github.com/runabove/venom/tree/master/executors/smtp
 
 ### SMTP
 

--- a/templater.go
+++ b/templater.go
@@ -1,7 +1,7 @@
 package venom
 
 import (
-	"encoding/json"
+	"gopkg.in/yaml.v2"
 	"fmt"
 	"strings"
 
@@ -33,9 +33,10 @@ func (tmpl *Templater) Add(prefix string, values map[string]string) {
 // Apply apply vars on string
 func (tmpl *Templater) Apply(step TestStep) (TestStep, error) {
 
-	log.Debugf("templater> before: %+v", step)
+	log.Debugf("templater> before: %#v", step)
 
-	s, err := json.Marshal(step)
+	// Using yaml to encode/decode, it generates map[interface{}]interface{} typed data that json does not like
+	s, err := yaml.Marshal(step)
 	if err != nil {
 		return nil, fmt.Errorf("templater> Error while marshaling: %s", err)
 	}
@@ -46,7 +47,7 @@ func (tmpl *Templater) Apply(step TestStep) (TestStep, error) {
 	}
 
 	var t TestStep
-	if err := json.Unmarshal([]byte(sb), &t); err != nil {
+	if err := yaml.Unmarshal([]byte(sb), &t); err != nil {
 		return nil, fmt.Errorf("templater> Error while unmarshal: %s", err)
 	}
 

--- a/tests/MyTestSuiteHTTP.yml
+++ b/tests/MyTestSuiteHTTP.yml
@@ -22,3 +22,13 @@ testcases:
     - result.statuscode ShouldEqual 401
     - result.headers.www-authenticate ShouldEqual X-OVH-Auth
     - result.timeseconds ShouldBeLessThan 1
+
+- name: POST http multipart
+  steps:
+  - type: http
+    method: POST
+    url: https://eu.api.ovh.com/1.0/auth/logout
+    multipart_form:
+      file: '@./venom.gif'
+    assertions:
+    - result.statuscode ShouldEqual 401


### PR DESCRIPTION
I need this feature, but I find my method too "hacky" because of encode/decode and behaviors of the used encoding libraries.

**First issue I came up with, in templater:** 
```
templater> Error while marshaling: json: unsupported type: map[interface {}]interface {}
templater> Error while marshaling: json: unsupported type: map[interface {}]interface {}
templater> Error while marshaling: json: unsupported type: map[interface {}]interface {}
```

It appears `json` does not really like `map[interface{}]interface{}` type (and does not know what to do with it), while `yaml` (it's the one producing this type) is okay with it (hence the modification in `templater.go`)

**Second issue I came up with, in the executor**

Basically, `mapstructure.Decode` does not know how to handle the `MultipartForm` field. I had to set values manually (and assert types later)

If you have any ideas on how to make all this less "hacky", please don't hesitate, you probably use more Golang than I do.

Also, I am not sure how you're making sure any change is not breaking the software, so I did not look into testing.